### PR TITLE
Removed broken testcase and added working one

### DIFF
--- a/django_settings/tests.py
+++ b/django_settings/tests.py
@@ -10,14 +10,8 @@ DJANGO_SETTINGS = settings.DJANGO_SETTINGS
 
 
 class SettingDefaults(TestCase):
-    def test_default_settings(self):
-        """
-        Test assuemes that following dict is in your settings.py file:
-        
-        DJANGO_SETTINGS = {
-           'application_limit': ('Integer', 2),
-           'admin_email': ('String', 'kuba.janoszek@gmail.com'),
-           }
-        """
-        value = Setting.objects.get_value('application_limit')
-        self.assertEquals(value, DJANGO_SETTINGS['application_limit'][1])
+    def test_settings(self):
+        """Test assumes that a properly formatted DJANGO_SETTINGS dict is in your settings.py"""
+        for key in DJANGO_SETTINGS:
+            value = Setting.objects.get_value(key)
+            self.assertEquals(value, DJANGO_SETTINGS[key][1])


### PR DESCRIPTION
The current test case makes an unnecessary assumption about the settings file being used.  This generalizes this test to ensure that the `DJANGO_SETTINGS` contents always match up with the `Setting` models.
