### PR TITLE
PEP8

### DIFF
--- a/django_settings/admin.py
+++ b/django_settings/admin.py
@@ -5,11 +5,9 @@ from django.contrib.contenttypes import generic
 from django_settings import models, forms
 
 
-
 def get_setting_value(obj):
     return obj.setting_object.value
 get_setting_value.short_description = _('Value')
-
 
 
 class SettingAdmin(admin.ModelAdmin):

--- a/django_settings/forms.py
+++ b/django_settings/forms.py
@@ -2,11 +2,10 @@
 from django import forms
 from django.db.models import Q
 from django.forms.models import modelform_factory
-from django.contrib.contenttypes.models import ContentType 
+from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import ugettext_lazy as _
 
 from django_settings import models
-
 
 
 class SettingForm(forms.ModelForm):
@@ -15,7 +14,6 @@ class SettingForm(forms.ModelForm):
         fields = ('setting_type', 'name')
 
     value = forms.CharField()
-
 
     def __init__(self, *a, **kw):
         forms.ModelForm.__init__(self, *a, **kw)
@@ -26,7 +24,6 @@ class SettingForm(forms.ModelForm):
         if instance:
             self.fields['value'].initial = getattr(instance.setting_object, 'value', '')
 
-
     def clean(self):
         cd = self.cleaned_data
         SettingClass = cd['setting_type'].model_class()
@@ -36,12 +33,11 @@ class SettingForm(forms.ModelForm):
         if not value:
             self._errors['value'] = self.error_class(['Value field cannot be empty.'])
         else:
-            setting_form = SettingClassForm({'value' : cd['value']})
+            setting_form = SettingClassForm({'value': cd['value']})
             if not setting_form.is_valid():
                 del cd['value']
                 self._errors['value'] = self.error_class(['Value is not valid.'])
         return cd
-
 
     def save(self, *args, **kwargs):
         cd = self.clean()
@@ -51,7 +47,7 @@ class SettingForm(forms.ModelForm):
             setting_object.delete()
 
         SettingClass = cd['setting_type'].model_class()
-        setting_object= SettingClass.objects.create(value=cd['value'])
+        setting_object = SettingClass.objects.create(value=cd['value'])
 
         kwargs['commit'] = False
         instance = forms.ModelForm.save(self, *args, **kwargs)

--- a/django_settings/management.py
+++ b/django_settings/management.py
@@ -6,16 +6,14 @@ from django.contrib.contenttypes.models import ContentType
 from django_settings import models
 
 
-
 DEFAULT_SETTINGS = getattr(settings, 'DJANGO_SETTINGS', {})
-
 
 
 def initialize_data(sender, **kwargs):
     for name, type_name_and_value in DEFAULT_SETTINGS.items():
         type_name, value = type_name_and_value
         SettingClass = ContentType.objects.get(app_label='django_settings', model=type_name.lower()).model_class()
-        
+
         if not models.Setting.objects.value_object_exists(name):
             models.Setting.objects.set_value(name, SettingClass, value)
 

--- a/django_settings/models.py
+++ b/django_settings/models.py
@@ -7,7 +7,6 @@ from django.db.models.signals import post_save
 from django.utils.translation import ugettext_lazy as _
 
 
-
 class BaseSetting(models.Model):
     class Meta:
         abstract = True
@@ -16,20 +15,16 @@ class BaseSetting(models.Model):
         return u'%s' % self.value
 
 
-
 class String(BaseSetting):
     value = models.CharField(max_length=254)
-
 
 
 class Integer(BaseSetting):
     value = models.IntegerField()
 
 
-
 class PositiveInteger(BaseSetting):
     value = models.PositiveIntegerField()
-
 
 
 class SettingManager(models.Manager):
@@ -39,11 +34,9 @@ class SettingManager(models.Manager):
                 return kw.get('default')
         return self.get(name=name).setting_object.value
 
-
     def value_object_exists(self, name):
         queryset = self.filter(name=name)
         return queryset.exists() and queryset[0].setting_object
-
 
     def set_value(self, name, SettingClass, value):
         setting = Setting(name=name)
@@ -56,7 +49,6 @@ class SettingManager(models.Manager):
         setting.setting_object = SettingClass.objects.create(value=value)
         setting.save()
         return setting
-
 
 
 class Setting(models.Model):

--- a/django_settings/tests.py
+++ b/django_settings/tests.py
@@ -8,12 +8,11 @@ from django_settings.models import Setting
 DJANGO_SETTINGS = settings.DJANGO_SETTINGS
 
 
-
 class SettingDefaults(TestCase):
     def test_default_settings(self):
         """
         Test assuemes that following dict is in your settings.py file:
-        
+
         DJANGO_SETTINGS = {
            'application_limit': ('Integer', 2),
            'admin_email': ('String', 'kuba.janoszek@gmail.com'),


### PR DESCRIPTION
Imposed the [pep8 style guide](http://www.python.org/dev/peps/pep-0008/), changing the use of whitespace throughout the code.
