### PR TITLE
Django 1.8 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Supported versions
 ------------------
 
 * Python: 2.6, 2.7  (python 2.6 requires importlib)
-* Django: 1.3, 1.4, 1.5
+* Django: 1.3, 1.4, 1.5, 1.6, 1.7, 1.8
 
 
 API

--- a/django_settings/__init__.py
+++ b/django_settings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-VERSION = '1.3.12'
+VERSION = '1.3.13'
 
 __version__ = VERSION
 __author__ = "Kuba Janoszek"

--- a/django_settings/models.py
+++ b/django_settings/models.py
@@ -2,7 +2,11 @@
 # framework
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
+import django
+if django.VERSION >= (1, 8):
+    from django.contrib.contenttypes import fields as generic_fields
+else:
+    from django.contrib.contenttypes import generic as generic_fields
 from django.utils.translation import ugettext_lazy as _
 from django.dispatch import receiver
 from django.db.models.signals import post_syncdb
@@ -59,7 +63,7 @@ class Setting(models.Model):
 
     setting_type = models.ForeignKey(ContentType)
     setting_id = models.PositiveIntegerField()
-    setting_object = generic.GenericForeignKey('setting_type', 'setting_id')
+    setting_object = generic_fields.GenericForeignKey('setting_type', 'setting_id')
 
     name = models.CharField(max_length=255, unique=conf.DJANGO_SETTINGS_UNIQUE_NAMES)
 


### PR DESCRIPTION
This removes an annoying deprecationwarning in django 1.8.

I've also tested django 1.7 and 1.8, and the module works ok in both.

If you please could merge this and send it to pypi, it would be awesome.

Thanks!