### PR TITLE
Override KeyMaker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,12 +147,30 @@ in your project settings:
 
    DJANGO_SETTINGS_TIMEOUT = 60 * 60 * 10  # 10 hours
 
-
 Timeout let's you define cache timeout (in sec.) for each of the
 settings. After the given time values gets expired and each of them
 will be recalculated (at the moment you ask for the given
 setting). Introduced due to django's defaults cache timeout (5 min):
 https://docs.djangoproject.com/en/dev/topics/cache/#cache-arguments
+
+If you want to override the cache key maker tell it in the settings:
+
+.. code-block:: python
+
+   DJANGO_SETTINGS_CACHE_KEYMAKER = 'myapp.django_settings_keymaker.TenantKeyMaker'
+
+And inherit from the default keymaker. (Example is for django-tenant-schemas based application)
+
+.. code-block:: python
+
+   from django.db import connection
+   from django_settings.keymaker import KeyMaker
+
+   class TenantKeyMaker(KeyMaker):
+       def make(self, method_name, args, kwargs):
+           key = super().make(method_name, args, kwargs)
+           key = connection.get_schema()+":"+key
+           return key
 
 
 Settings types
@@ -165,7 +183,6 @@ Admin
 -----
 
 You can manipulate setting via your admin interface.
-
 
 Changelog
 ---------

--- a/django_settings/cache.py
+++ b/django_settings/cache.py
@@ -9,49 +9,25 @@ a set of tools that makes method caching a little more flexible that simple
 XXX: the whole mechanism should be fixed as now it's too complicated to explain
 """
 from .lazyimport import lazyimport
+import importlib
 
 django = lazyimport({
     'settings': 'django.conf',
 })
 config = lazyimport({
     'DJANGO_SETTINGS_TIMEOUT': 'django_settings.conf',
+    'DJANGO_SETTINGS_CACHE_KEYMAKER': 'django_settings.conf'
 })
-
-
-class KeyMaker(object):
-    def __init__(self, prefix):
-        self.prefix = prefix
-
-    def convert(self, arg):
-        if isinstance(arg, unicode):
-            return arg.encode(django.settings.DEFAULT_CHARSET)
-        else:
-            return str(arg)
-
-    def args_to_key(self, args):
-        return ":".join(map(self.convert, args))
-
-    def kwargs_to_key(self, kwargs):
-        return ":".join([
-            "%s:%s" % (self.convert(k), self.convert(v))
-            for k, v in kwargs.items()
-        ])
-
-    def make(self, method_name, args, kwargs):
-        key = ":".join((
-            self.prefix,
-            method_name,
-            self.args_to_key(args),
-            self.kwargs_to_key(kwargs),
-        ))
-        return key
-
 
 class MethodProxy(object):
     def __init__(self, instance, method):
         self.instance = instance
         self.method = method  # accually it's NOT bounded s it's a function!
-        self._keymaker = KeyMaker(prefix='django_settings')
+        keymakerklass = config.DJANGO_SETTINGS_CACHE_KEYMAKER
+        if isinstance(keymakerklass, str):
+            module_name, class_name = keymakerklass.rsplit(".", 1)
+            keymakerklass = getattr(importlib.import_module(module_name), class_name)
+        self._keymaker = keymakerklass(prefix='django_settings')
 
         # NOTE: it's proxy, so let's add at least some basic func properties
         self.func_name = self.method.__name__

--- a/django_settings/conf.py
+++ b/django_settings/conf.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
+from .keymaker import KeyMaker
 
 DJANGO_SETTINGS_UNIQUE_NAMES = getattr(settings, 'DJANGO_SETTINGS_UNIQUE_NAMES', True)
 DJANGO_SETTINGS_TIMEOUT = getattr(settings, 'DJANGO_SETTINGS_TIMEOUT', 60 * 60 * 24 * 1)  # one day
+DJANGO_SETTINGS_CACHE_KEYMAKER = getattr(settings, 'DJANGO_SETTINGS_CACHE_KEYMAKER', KeyMaker)
 DJANGO_SETTINGS = getattr(settings, 'DJANGO_SETTINGS', None) or {}

--- a/django_settings/keymaker.py
+++ b/django_settings/keymaker.py
@@ -1,8 +1,12 @@
+import sys
+
 class KeyMaker(object):
     def __init__(self, prefix):
         self.prefix = prefix
 
     def convert(self, arg):
+        if sys.version_info < (3,) and isinstance(arg, unicode):
+            return arg.encode(django.settings.DEFAULT_CHARSET)
         return str(arg)
 
     def args_to_key(self, args):

--- a/django_settings/keymaker.py
+++ b/django_settings/keymaker.py
@@ -1,0 +1,26 @@
+class KeyMaker(object):
+    def __init__(self, prefix):
+        self.prefix = prefix
+
+    def convert(self, arg):
+        return str(arg)
+
+    def args_to_key(self, args):
+        return ":".join(map(self.convert, args))
+
+    def kwargs_to_key(self, kwargs):
+        return ":".join([
+            "%s:%s" % (self.convert(k), self.convert(v))
+            for k, v in kwargs.items()
+        ])
+
+    def make(self, method_name, args, kwargs):
+        key = ":".join((
+            self.prefix,
+            method_name,
+            self.args_to_key(args),
+            self.kwargs_to_key(kwargs),
+        ))
+        return key
+
+


### PR DESCRIPTION
One can use DJANGO_SETTINGS_CACHE_KEYMAKER to override the KeyMaker class.

The KeyMaker class supports both Python 2 and Python 3
