### PR TITLE
Don't use the deprecated HttpRequest.REQUEST

### DIFF
--- a/django_settings/admin.py
+++ b/django_settings/admin.py
@@ -50,7 +50,7 @@ class SettingAdmin(admin.ModelAdmin):
         if obj:
             return obj.setting_object.__class__
         try:
-            typename = request.REQUEST['typename']        # NOTE: both lines might
+            typename = request.GET['typename']        # NOTE: both lines might
             return dataapi.data.model_for_name(typename)  # raise KeyError
         except KeyError:
             raise Http404


### PR DESCRIPTION
[HttpRequest.REQUEST](https://docs.djangoproject.com/en/1.7/ref/request-response/#django.http.HttpRequest.REQUEST) is deprecated since Django 1.7. Use [HttpRequest.GET](https://docs.djangoproject.com/en/dev/ref/request-response/#django.http.HttpRequest.GET) instead
