### PR TITLE
Upgrade to Django 1.9 (backward compatible)

### DIFF
--- a/django_settings/admin.py
+++ b/django_settings/admin.py
@@ -50,7 +50,7 @@ class SettingAdmin(admin.ModelAdmin):
         if obj:
             return obj.setting_object.__class__
         try:
-            typename = request.REQUEST['typename']        # NOTE: both lines might
+            typename = request.GET['typename']        # NOTE: both lines might
             return dataapi.data.model_for_name(typename)  # raise KeyError
         except KeyError:
             raise Http404

--- a/django_settings/models.py
+++ b/django_settings/models.py
@@ -8,7 +8,10 @@ except:
     from django.contrib.contenttypes.generic import GenericForeignKey
 from django.utils.translation import ugettext_lazy as _
 from django.dispatch import receiver
-from django.db.models.signals import post_syncdb
+try:
+    from django.db.models.signals import post_migrate
+except:
+    from django.db.models.signals import post_syncdb as post_migrate
 
 from .moduleregistry import new_registry
 
@@ -114,7 +117,7 @@ registry.register(PositiveInteger)
 # end ###################
 
 
-@receiver(post_syncdb)
+@receiver(post_migrate)
 def handle_post_syncdb(sender, **kwargs):
     from django_settings.dataapi import initialize_data
     initialize_data()

--- a/django_settings/models.py
+++ b/django_settings/models.py
@@ -2,7 +2,10 @@
 # framework
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
+try:
+    from django.contrib.contenttypes.fields import GenericForeignKey
+except:
+    from django.contrib.contenttypes.generic import GenericForeignKey
 from django.utils.translation import ugettext_lazy as _
 from django.dispatch import receiver
 from django.db.models.signals import post_syncdb
@@ -61,7 +64,7 @@ class Setting(models.Model):
 
     setting_type = models.ForeignKey(ContentType)
     setting_id = models.PositiveIntegerField()
-    setting_object = generic.GenericForeignKey('setting_type', 'setting_id')
+    setting_object = GenericForeignKey('setting_type', 'setting_id')
 
     name = models.CharField(max_length=255, unique=conf.DJANGO_SETTINGS_UNIQUE_NAMES)
 

--- a/django_settings/templatetags/settings_admin_urls.py
+++ b/django_settings/templatetags/settings_admin_urls.py
@@ -8,7 +8,11 @@ register = template.Library()
 @register.filter
 def add_url_for_setting_type(admin_change_list, type_name):
     cl = admin_change_list
-    url_name = 'admin:%s_%s_%s' % (cl.opts.app_label, cl.opts.module_name, 'add')
+    try:
+        model_name = cl.opts.model_name
+    except AttributeError:
+        model_name = cl.opts.module_name
+    url_name = 'admin:%s_%s_%s' % (cl.opts.app_label, model_name, 'add')
     query = "typename=%(type)s%(popup)s" % dict(
         type=type_name,
         popup='_popup=1' if cl.is_popup else '',


### PR DESCRIPTION
- Use `post_migrate` signal instead of `post_syncdb` ([post_syncdb is deprecated since Django 1.7](https://docs.djangoproject.com/en/1.7/ref/signals/#post-syncdb))
- Update import of `GenericForeignKey` ([Moved in Django 1.7](https://docs.djangoproject.com/en/1.7/ref/contrib/contenttypes/#django.contrib.contenttypes.fields.GenericForeignKey))
- Use `Model._meta.model_name` ([Model._meta.module_name alias was removed in Django 1.8](https://docs.djangoproject.com/en/1.8/releases/1.8/#features-removed-in-1-8))
- Use `HttpRequest.GET` instead of `HttpRequest.REQUEST` ([HttpRequest.REQUEST is deprecated since Django 1.7](https://docs.djangoproject.com/en/1.7/ref/request-response/#django.http.HttpRequest.REQUEST))
